### PR TITLE
kiwi: Update init & overlay for CDMA variants

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -136,10 +136,6 @@ PRODUCT_PACKAGES += \
     FMRadio \
     libfmjni
 
-# Gello
-PRODUCT_PACKAGES += \
-    Gello
-
 # GPS
 PRODUCT_PACKAGES += \
     gps.msm8916

--- a/init/init_kiwi.cpp
+++ b/init/init_kiwi.cpp
@@ -40,92 +40,105 @@ typedef struct {
     string model;
     string description;
     string fingerprint;
+    string default_network;
     bool is_cdma;
 } match_t;
 
 static match_t matches[] = {
-    /* Honor 5x USA L24 */
+    /* Honor 5x USA L24 (LTE, GSM/WCDMA) */
     {
         "KIW-L24",
         "KIW-L24-user 5.1.1 GRJ90 C567B140 release-keys",
         "HONOR/KIW-L24/HNKIW-Q:5.1.1/HONORKIW-L24/C567B140:user/release-keys",
+        "9",
         false
     },
-    /* Honor 5x Russia L23 */
+    /* Honor 5x Russia L23 (LTE, GSM/WCDMA) */
     {
         "KIW-L23",
         "KIW-L23-user 5.1.1 GRJ90 C567B140 release-keys",
         "HONOR/KIW-L23/HNKIW-Q:5.1.1/HONORKIW-L23/C567B140:user/release-keys",
+        "9",
         false
     },
-    /* Honor 5x India L22 */
+    /* Honor 5x India L22 (LTE, GSM/WCDMA) */
     {
         "KIW-L22",
         "KIW-L22-user 5.1.1 GRJ90 C675B130 release-keys",
         "HONOR/KIW-L22/HNKIW-Q:5.1.1/HONORKIW-L22/C675B130:user/release-keys",
+        "9",
         false
     },
-    /* Honor 5x EU L21 */
+    /* Honor 5x EU L21 (LTE, GSM/WCDMA) */
     {
         "KIW-L21",
         "KIW-L21-user 5.1.1 GRJ90 C432B130 release-keys",
         "HONOR/KIW-L21/HNKIW-Q:5.1.1/HONORKIW-L21/C432B130:user/release-keys",
+        "9",
         false
     },
-    /* Honor 5x AL10 Chinese */
+    /* Honor 5x AL10 Chinese (TD-SCDMA/LTE/GSM/WCDMA, CDMA, and EvDo) */
     {
         "KIW-AL10",
         "KIW-AL10-user 5.1.1 GRJ90 C92B175 release-keys",
         "HONOR/KIW-AL10/HNKIW-Q:5.1.1/HONORKIW-AL10/C92B175:user/release-keys",
-        false
+        "22",
+        true
     },
-    /* Honor 5x AL20 Chinese */
+    /* Honor 5x AL20 Chinese (TD-SCDMA/LTE/GSM/WCDMA, CDMA, and EvDo) */
     {
         "KIW-AL20",
         "KIW-AL20-user 5.1.1 GRJ90 C432B130 release-keys",
         "HONOR/KIW-AL20/HNKIW-Q:5.1.1/HONORKIW-AL20/C432B130:user/release-keys",
-        false
+        "22",
+        true
     },
-    /* Chinese WCDMA version KIW-UL00 */
+    /* Chinese WCDMA/TD-SCDMA version KIW-UL00 (TD-SCDMA, GSM/WCDMA and LTE) */
     {
         "KIW-UL00",
         "KIW-UL00-user 5.1.1 GRJ90 C00B140 release-keys",
         "HONOR/KIW-UL00/HNKIW-Q:5.1.1/HONORKIW-UL00/C00B140:user/release-keys",
+        "20",
         false
     },
-    /* Chinese CDMA version KIW-CL00 */
+    /* Chinese CDMA version KIW-CL00 (LTE, CDMA and EvDo) */
     {
         "KIW-CL00",
         "KIW-CL00-user 5.1.1 GRJ90 C92B140 release-keys",
         "HONOR/KIW-CL00/HNKIW-Q:5.1.1/HONORKIW-CL00/C92B140:user/release-keys",
+        "8",
         true
     },
-    /* Chinese TD-SCDMA version KIW-TL00H */
+    /* Chinese TD-SCDMA version KIW-TL00H (TD-SCDMA,GSM and LTE) */
     {
         "KIW-TL00H",
         "KIW-TL00H-user 5.1.1 GRJ90 C00B140 release-keys",
         "HONOR/KIW-TL00H/HNKIW-Q:5.1.1/HONORKIW-TL00H/C00B140:user/release-keys",
-        true
+        "17",
+        false
     },
-    /* Chinese TD-SCDMA version KIW-TL00 */
+    /* Chinese TD-SCDMA version KIW-TL00 (TD-SCDMA,GSM and LTE) */
     {
         "KIW-TL00",
         "KIW-TL00-user 5.1.1 GRJ90 C00B140 release-keys",
         "HONOR/KIW-TL00/HNKIW-Q:5.1.1/HONORKIW-TL00/C00B140:user/release-keys",
-        true
+        "17",
+        false
     },
-    /* HUAWEI GR5 version KII-L22 (same as honor, evidently from Japan) */
+    /* HUAWEI GR5 version KII-L22 (same as honor, evidently from Japan) (LTE, GSM/WCDMA) */
     {
         "KII-L22",
         "KII-L22-user 5.1.1 GRJ90 C635B131 release-keys",
         "HUAWEI/KII-L22/HWKII-Q:5.1.1/HUAWEIKII-L22/C635B131:user/release-keys",
+        "9",
         false
     },
-    /* HUAWEI GR5 version KII-L21 (same as honor) */
+    /* HUAWEI GR5 version KII-L21 (same as honor) (LTE, GSM/WCDMA) */
     {
         "KII-L21",
         "KII-L21-user 5.1.1 GRJ90 C185B130 release-keys",
         "HUAWEI/KII-L21/HWKII-Q:5.1.1/HUAWEIKII-L21/C185B130:user/release-keys",
+        "9",
         false
     },
     /* HUAWEI GR5 version KII-L05 (same as honor, from Canada) */
@@ -133,6 +146,7 @@ static match_t matches[] = {
         "KII-L05",
         "KII-L05-user 6.0.1 GRJ90 C654B340 release-keys",
         "HUAWEI/KII-L05/HWKII-Q:6.0.1/HUAWEIKII-L05/C654B340:user/release-keys",
+        "9",
         false
     },
 };
@@ -188,10 +202,11 @@ void vendor_load_properties()
     hwsim = property_get("ro.boot.hwsim");
 
     if (hwsim == "single") {
-        property_set("ro.telephony.default_network", "9");
+        property_set("ro.telephony.default_network", match->default_network);
     } else {
         property_set("persist.radio.multisim.config", "dsds");
         property_set("ro.telephony.ril.config", "simactivation,sim2gsmonly");
-        property_set("ro.telephony.default_network", "9,9");
+        property_set("ro.telephony.default_network", match->default_network + "," +
+                match->default_network);
     }
 }

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -169,7 +169,7 @@
     <!-- The RadioAccessFamilies supported by the device. + Empty is
          viewed as "all".  Only used on devices which + don't support
          RIL_REQUEST_GET_RADIO_CAPABILITY + format is UMTS|LTE|... -->
-    <string translatable="false" name="config_radio_access_family">GSM|UMTS|LTE</string>
+    <string translatable="false" name="config_radio_access_family">GSM|UMTS|LTE|CDMA|EVDO</string>
 
     <!-- Operating voltage for bluetooth controller. 0 by default-->
     <integer name="config_bluetooth_operating_voltage_mv">3300</integer>

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -104,25 +104,6 @@ on boot
 
     #To allow interfaces to get v6 address when tethering is enabled
     write /proc/sys/net/ipv6/conf/rmnet0/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet1/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet2/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet3/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet4/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet5/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet6/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet7/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio0/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio1/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio2/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio3/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio4/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio5/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio6/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_sdio7/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_usb0/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_usb1/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_usb2/accept_ra 2
-    write /proc/sys/net/ipv6/conf/rmnet_usb3/accept_ra 2
 
     # To prevent out of order acknowledgements from making
     # connection tracking to treat them as not belonging to
@@ -191,16 +172,6 @@ on post-fs-data
     # We chown/chmod /persist again so because mount is run as root + defaults
     chown system system /persist
     chmod 0771 /persist
-    chmod 0664 /sys/devices/platform/msm_sdcc.1/polling
-    chmod 0664 /sys/devices/platform/msm_sdcc.2/polling
-    chmod 0664 /sys/devices/platform/msm_sdcc.3/polling
-    chmod 0664 /sys/devices/platform/msm_sdcc.4/polling
-
-    # Chown polling nodes as needed from UI running on system server
-    chown system system /sys/devices/platform/msm_sdcc.1/polling
-    chown system system /sys/devices/platform/msm_sdcc.2/polling
-    chown system system /sys/devices/platform/msm_sdcc.3/polling
-    chown system system /sys/devices/platform/msm_sdcc.4/polling
 
     #Create the symlink to qcn wpa_supplicant folder for ar6000 wpa_supplicant
     mkdir /data/system 0775 system system

--- a/rootdir/etc/init.target-from-init.rc
+++ b/rootdir/etc/init.target-from-init.rc
@@ -45,28 +45,17 @@ on post-fs-data
 
     mkdir /data/midi 0770 media audio
 
-    start goldeneye
-    start goldeneye_test
-
     chown system system /sys/devices/12c.hw-dev-detect/dev_flag
-    chown system system /sys/touch_screen/touch_mmi_test
-    chown system system /sys/touch_screen/touch_calibration
-    chown system system /sys/touch_screen/synaptics_mmi_test_result
-    chown system system /sys/touch_screen/synaptics_mmi_test
     chown system system /sys/touch_screen/holster_touch_window
-    chown system system /sys/bus/ttsp4/devices/main_ttsp_core.cyttsp4_i2c_adapter/signal_disparity
-    chown system system /sys/bus/ttsp4/devices/main_ttsp_core.cyttsp4_i2c_adapter/finger_threshold 
     chown system system /sys/touch_screen/glove_func/signal_disparity
-    chown system system /sys/touch_screen/glove_func/holster_sensitivity
-    chown system system /sys/touch_screen/glove_func/finger_threshold 
     chown system system /sys/touch_screen/easy_wakeup_gesture
     chown system system /sys/touch_screen/easy_wakeup_supported_gestures
     chown system system /sys/touch_screen/easy_wakeup_position
-    chown system system /sys/touch_screen/openshort
 
     chown system system /sys/touch_screen/cyttsp5/command
     chown system system /sys/touch_screen/cyttsp5/status
     chown system system /sys/touch_screen/cyttsp5/response
+    chown system system /sys/touch_screen/touch_mmi_test
     chown system system /sys/touch_screen/touch_mmi_test/calibrate_idacs
     chown system system /sys/touch_screen/touch_mmi_test/disable_single_tx
     chown system system /sys/touch_screen/touch_mmi_test/enable_single_tx
@@ -143,27 +132,7 @@ on post-fs-data
     chown system system /sys/class/graphics/fb0/lcd_comform_mode
     chown system system /sys/class/graphics/fb0/lcd_support_mode
 
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_calib_target
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_calibration
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_device_name
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_enable
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_force_calib
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_reg_read
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_reg_write
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_status
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_prox_status
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_cap_value
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_sw_reset
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_threshold
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_update_calib
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_update_config
-    chown system system /sys/bus/i2c/devices/0-002c/adux1050_vendor
     mkdir /data/log/sar_cap system system
-    chown system system /sys/bus/i2c/devices/0-001e/ps_calibration
-    chown system system /sys/bus/i2c/devices/0-001e/txc_pa2240_calibration
-    chown system system /sys/bus/i2c/devices/0-001e/txc_pa2240_calibration_result
-    chown system system /sys/bus/i2c/devices/0-001e/dump_reg
-    chown system system /sys/bus/i2c/devices/0-001e/pdata
     chown system system /sys/bus/i2c/devices/0-0038/module_tpcolor
     chown system system /sys/bus/i2c/devices/0-0052/module_tpcolor
     chown media media /sys/bus/platform/drivers/qcom,ois/0.qcom,ois/ois_pixel
@@ -177,26 +146,6 @@ service drm /system/bin/drmserver
     class main
     user drm
     group drm system inet drmrpc sdcard_rw media_rw shell
-
-service ddrtest /system/bin/do_ddrtest
-    user root
-    disabled
-    oneshot
-
-service stop_ddrtest /system/bin/do_ddrtest
-    user root
-    disabled
-    oneshot
-
-on property:debug.rt.ddr.test=1
-    stop ddrtest
-    start ddrtest
-on property:debug.rt.ddr.test=2
-    start ddrtest
-on property:debug.rt.ddr.test=3
-    start ddrtest
-on property:debug.rt.ddr.test=4
-    start stop_ddrtest
 
 service rmt_oeminfo /system/bin/rmt_oeminfo
     class core
@@ -216,54 +165,14 @@ service libqmi_oem_main /system/bin/libqmi_oem_main
     class main
     group wakelock
 
-service rebootmgr /system/bin/rebootmgr
-    class core
-    oneshot
-    disabled
-
 # disable enable_swap
-
-service wifi_aging /system/xbin/wifi_aging
-    user root
-    disabled
-    oneshot
-
-service wifi_power_off /system/xbin/wifi_power_off
-    user root
-    disabled
-    oneshot
-
-service bt_aging /system/xbin/bt_aging
-    user root
-    group bluetooth net_bt_admin system
-    disabled
-    oneshot
-
-service bt_power_off /system/xbin/bt_power_off
-    user root
-    group bluetooth net_bt_admin system
-    disabled
-    oneshot
 
 service huawei_version /system/bin/huawei_version
     class core
     user root
     oneshot
 
-service test_diag /sbin/test_diag
-    user root
-    disabled
-    seclabel u:r:test_diag:s0
-
-service send_data_srv /system/bin/send_data_srv
-    class core
-    user system
-    group system
-    disabled
-    oneshot
-
 on property:ro.runmode=factory
-    start send_data_srv
     mkdir /data/img 0777 media media
     mkdir /data/camera 0777 camera camera
     mkdir /data/misp 0777 root root
@@ -272,9 +181,6 @@ on property:ro.runmode=factory
 on property:persist.sys.hlcharging=true
     write /sys/class/power_supply/battery/device/not_limit_chrg_flag 1
     mkdir system/etc/tp_test_parameters
-
-on property:ro.cust.complete="true"
-    start  rebootmgr
 
 on property:hw.accel.calib="true"
     chmod 0664 /dev/input/event*

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -78,16 +78,6 @@ on property:persist.usb.chgdisabled=1
 on property:persist.usb.chgdisabled=0
     write /sys/class/power_supply/battery/charging_enabled 1
 
-service qrngp /system/bin/qrngp -f
-   class main
-   user root
-   group root
-   oneshot
-   disabled
-
-on property:sys.boot_completed=1
-   start qrngp
-
 service qseecomd /system/bin/qseecomd
    class core
    user root
@@ -151,23 +141,6 @@ service imsqmidaemon /system/bin/imsqmidaemon
     user system
     socket ims_qmid stream 0660 system radio
     group radio net_raw log qcom_diag
-
-service ims_rtp_daemon /system/bin/ims_rtp_daemon
-   class main
-   user system
-   socket ims_rtpd stream 0660 system radio
-   group radio net_raw diag qcom_diag log
-   disabled
-
-service imscmservice /system/bin/imscmservice
-   class main
-   user system
-   group radio net_raw diag qcom_diag log
-   disabled
-
-on property:sys.ims.DATA_DAEMON_STATUS=1
-    start ims_rtp_daemon
-    start imscmservice
 
 on charger-fs
     mount ext4 /dev/block/bootdevice/by-name/userdata /data rw

--- a/sepolicy/mediaserver.te
+++ b/sepolicy/mediaserver.te
@@ -1,3 +1,4 @@
 allow mediaserver smartamp_device:chr_file { read write ioctl open };
 allow mediaserver audiod:binder call;
 allow mediaserver sensorservice_service:service_manager find;
+allow mediaserver camera_data_file:dir search;


### PR DESCRIPTION
Set ro.telephony.default_network for different variants.
KIW-TL00H and KIW-TL00 are not CDMA devices.
KIW-AL10 and KIW-AL20 are CDMA devices.
Add CDMA|EVDO to overlay.

Change-Id: I450c3dc9898302aaeb79129da1f4a9be46539162